### PR TITLE
Add more CI steps to test C program

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,12 @@ install:
 script:
   - npm run lint
   - npm run flow
-  - npm run build:program-c
   - npm run build:program-rust
   - npm run test:program-rust
   - npm run cluster:localnet
+  - npm run localnet:update
+  - npm run localnet:up
   - npm run start
+  - npm run build:program-c
+  - npm run start
+  - npm run localnet:down

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -36,5 +36,6 @@ async function main() {
 main()
   .catch(err => {
     console.error(err);
+    process.exit(1);
   })
   .then(() => process.exit());


### PR DESCRIPTION
**Problem**

Travis has been broken for a bit on the `npm start` line, but the JS test program was exiting with status 0 anyway.  Additionally, we weren't testing the C program separately.

**Solution**

Add more CI steps to capture the C program, and return a new exit code in JS.