### PR TITLE
ws error: connect ECONNREFUSED 127.0.0.1:8900

### DIFF
--- a/README-installation-notes.md
+++ b/README-installation-notes.md
@@ -47,8 +47,9 @@ $ brew cask install virtualbox
 $ docker-machine create --driver virtualbox default
 # To see config info:
 $ docker-machine env default
-# Port forwarding of 8899 from your OS to the Docker machine:
+# Port forwarding of 8899 and 8900 from your OS to the Docker machine:
 $ docker-machine ssh default -f -N -L 8899:localhost:8899
+$ docker-machine ssh default -f -N -L 8900:localhost:8900
 # To configure your shell to use the docker-machine
 $ eval "$(docker-machine env default)"
 ```


### PR DESCRIPTION
The Rust version requires access to port 8900. You'll get the error: "ws error: connect ECONNREFUSED 127.0.0.1:8900" if you run the rust version and the port forwarding is not set up. For completeness and to make the helloworld experience as error-free and troubleshoot-free as possible, I think we should add the port forwarding command to the installation instructions.