### PR TITLE
Use gitpod docker image

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,6 +2,3 @@ FROM gitpod/workspace-full
 
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.4.8/install)"
 RUN export PATH=~/.local/share/solana/install/active_release/bin:$PATH
-RUN npm install
-RUN npm run build:program-rust
-RUN npm run cluster:devnet

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.4.8/install)"
+RUN export PATH=~/.local/share/solana/install/active_release/bin:$PATH
+RUN npm install
+RUN npm run build:program-rust
+RUN npm run cluster:devnet

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,12 @@
 image:
   file: .gitpod.Dockerfile
 tasks:
-  - command: |
+  - init: |
+      export PATH=~/.local/share/solana/install/active_release/bin:$PATH
+      npm install
+      npm run build:program-rust
+      npm run cluster:devnet
+    command: |
       rustup toolchain link bpf node_modules/@solana/web3.js/bpf-sdk/dependencies/rust-bpf
       gp open README-gitpod.md
 github:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,16 +1,9 @@
+image:
+  file: .gitpod.Dockerfile
 tasks:
-  - init: |
-      sh -c "$(curl -sSfL https://release.solana.com/v1.4.8/install)"
-      export PATH=~/.local/share/solana/install/active_release/bin:$PATH
-      npm install
-      npm run build:program-rust
-      npm run cluster:devnet
-    command: |
+  - command: |
       rustup toolchain link bpf node_modules/@solana/web3.js/bpf-sdk/dependencies/rust-bpf
-      sh -c "$(curl -sSfL https://release.solana.com/v1.4.8/install)"
-      export PATH=~/.local/share/solana/install/active_release/bin:$PATH
       gp open README-gitpod.md
-image: gitpod/workspace-full
 github:
   prebuilds:
     # enable for the master/default branch (defaults to true)


### PR DESCRIPTION
gitpod does not retain the user directories so the solana tools are not retained in pre-builds.  By using the docker image to install the tools the user directory is retained.