### PR TITLE
[docs] Fixing link to the on-chain programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,8 @@ The program is written using:
 To learn more about Solana programming model refer to the [Programming Model
 Overview](https://docs.solana.com/developing/programming-model/overview).
 
-To learn more about developing programs on Solana refer to the [Deployed
-Programs
-Overview](https://docs.solana.com/developing/deployed-programs/overview)
+To learn more about developing programs on Solana refer to the [On-Chain 
+Programs Overview](https://docs.solana.com/developing/on-chain-programs/overview)
 
 ## Pointing to a public Solana cluster
 


### PR DESCRIPTION
subj

Current link to "Deployed Programs Overview" is broken, seems like the content is now located at "On-Chain Programs Overview": https://docs.solana.com/developing/on-chain-programs/overview