### PR TITLE
Update to keypair

### DIFF
--- a/src/client/hello_world.ts
+++ b/src/client/hello_world.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import {
-  Account,
+  Keypair,
   Connection,
   PublicKey,
   LAMPORTS_PER_SOL,
@@ -30,7 +30,7 @@ let connection: Connection;
 /**
  * Account (keypair)
  */
-let payerAccount: Account;
+let payerAccount: Keypair;
 
 /**
  * Hello world's program id

--- a/src/client/hello_world.ts
+++ b/src/client/hello_world.ts
@@ -19,7 +19,7 @@ import {
   getPayer,
   getRpcUrl,
   newAccountWithLamports,
-  readAccountFromFile,
+  createKeypairFromFile,
 } from './utils';
 
 /**
@@ -28,9 +28,9 @@ import {
 let connection: Connection;
 
 /**
- * Account (keypair)
+ * Keypair associated to the fees' payer
  */
-let payerAccount: Keypair;
+let payer: Keypair;
 
 /**
  * Hello world's program id
@@ -103,7 +103,7 @@ export async function establishConnection(): Promise<void> {
  */
 export async function establishPayer(): Promise<void> {
   let fees = 0;
-  if (!payerAccount) {
+  if (!payer) {
     const {feeCalculator} = await connection.getRecentBlockhash();
 
     // Calculate the cost to fund the greeter account
@@ -114,18 +114,18 @@ export async function establishPayer(): Promise<void> {
 
     try {
       // Get payer from cli config
-      payerAccount = await getPayer();
+      payer = await getPayer();
     } catch (err) {
       // Fund a new payer via airdrop
-      payerAccount = await newAccountWithLamports(connection, fees);
+      payer = await newAccountWithLamports(connection, fees);
     }
   }
 
-  const lamports = await connection.getBalance(payerAccount.publicKey);
+  const lamports = await connection.getBalance(payer.publicKey);
   if (lamports < fees) {
     // This should only happen when using cli config keypair
     const sig = await connection.requestAirdrop(
-      payerAccount.publicKey,
+      payer.publicKey,
       fees - lamports,
     );
     await connection.confirmTransaction(sig);
@@ -133,7 +133,7 @@ export async function establishPayer(): Promise<void> {
 
   console.log(
     'Using account',
-    payerAccount.publicKey.toBase58(),
+    payer.publicKey.toBase58(),
     'containing',
     lamports / LAMPORTS_PER_SOL,
     'SOL to pay for fees',
@@ -146,8 +146,8 @@ export async function establishPayer(): Promise<void> {
 export async function checkProgram(): Promise<void> {
   // Read program id from keypair file
   try {
-    const programAccount = await readAccountFromFile(PROGRAM_KEYPAIR_PATH);
-    programId = programAccount.publicKey;
+    const programKeypair = await createKeypairFromFile(PROGRAM_KEYPAIR_PATH);
+    programId = programKeypair.publicKey;
   } catch (err) {
     const errMsg = (err as Error).message;
     throw new Error(
@@ -170,10 +170,10 @@ export async function checkProgram(): Promise<void> {
   }
   console.log(`Using program ${programId.toBase58()}`);
 
-  // Derive the address of a greeting account from the program so that it's easy to find later.
+  // Derive the address (public key) of a greeting account from the program so that it's easy to find later.
   const GREETING_SEED = 'hello';
   greetedPubkey = await PublicKey.createWithSeed(
-    payerAccount.publicKey,
+    payer.publicKey,
     GREETING_SEED,
     programId,
   );
@@ -192,8 +192,8 @@ export async function checkProgram(): Promise<void> {
 
     const transaction = new Transaction().add(
       SystemProgram.createAccountWithSeed({
-        fromPubkey: payerAccount.publicKey,
-        basePubkey: payerAccount.publicKey,
+        fromPubkey: payer.publicKey,
+        basePubkey: payer.publicKey,
         seed: GREETING_SEED,
         newAccountPubkey: greetedPubkey,
         lamports,
@@ -201,7 +201,7 @@ export async function checkProgram(): Promise<void> {
         programId,
       }),
     );
-    await sendAndConfirmTransaction(connection, transaction, [payerAccount]);
+    await sendAndConfirmTransaction(connection, transaction, [payer]);
   }
 }
 
@@ -218,7 +218,7 @@ export async function sayHello(): Promise<void> {
   await sendAndConfirmTransaction(
     connection,
     new Transaction().add(instruction),
-    [payerAccount],
+    [payer],
   );
 }
 

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import fs from 'mz/fs';
 import path from 'path';
 import yaml from 'yaml';
-import {Account, Connection} from '@solana/web3.js';
+import {Keypair, Connection} from '@solana/web3.js';
 
 // zzz
 export function sleep(ms: number): Promise<void> {
@@ -16,8 +16,8 @@ export function sleep(ms: number): Promise<void> {
 export async function newAccountWithLamports(
   connection: Connection,
   lamports = 1000000,
-): Promise<Account> {
-  const account = new Account();
+): Promise<Keypair> {
+  const account = Keypair.generate();
   const signature = await connection.requestAirdrop(
     account.publicKey,
     lamports,
@@ -61,7 +61,7 @@ export async function getRpcUrl(): Promise<string> {
 /**
  * Load and parse the Solana CLI config file to determine which payer to use
  */
-export async function getPayer(): Promise<Account> {
+export async function getPayer(): Promise<Keypair> {
   try {
     const config = await getConfig();
     if (!config.keypair_path) throw new Error('Missing keypair path');
@@ -70,15 +70,15 @@ export async function getPayer(): Promise<Account> {
     console.warn(
       'Failed to read keypair from CLI config file, falling back to new random keypair',
     );
-    return new Account();
+    return Keypair.generate();
   }
 }
 
 /**
  * Create an Account from a keypair file
  */
-export async function readAccountFromFile(filePath: string): Promise<Account> {
+export async function readAccountFromFile(filePath: string): Promise<Keypair> {
   const keypairString = await fs.readFile(filePath, {encoding: 'utf8'});
-  const keypairBuffer = Buffer.from(JSON.parse(keypairString));
-  return new Account(keypairBuffer);
+  const keypairBuffer = Uint8Array.from(JSON.parse(keypairString));
+  return Keypair.fromSecretKey(keypairBuffer);
 }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -17,13 +17,13 @@ export async function newAccountWithLamports(
   connection: Connection,
   lamports = 1000000,
 ): Promise<Keypair> {
-  const account = Keypair.generate();
+  const keypair = Keypair.generate();
   const signature = await connection.requestAirdrop(
-    account.publicKey,
+    keypair.publicKey,
     lamports,
   );
   await connection.confirmTransaction(signature);
-  return account;
+  return keypair;
 }
 
 /**
@@ -65,20 +65,20 @@ export async function getPayer(): Promise<Keypair> {
   try {
     const config = await getConfig();
     if (!config.keypair_path) throw new Error('Missing keypair path');
-    return readAccountFromFile(config.keypair_path);
+    return createKeypairFromFile(config.keypair_path);
   } catch (err) {
     console.warn(
-      'Failed to read keypair from CLI config file, falling back to new random keypair',
+      'Failed to create keypair from CLI config file, falling back to new random keypair',
     );
     return Keypair.generate();
   }
 }
 
 /**
- * Create an Account from a keypair file
+ * Create a Keypair from a secret key stored in file as bytes' array
  */
-export async function readAccountFromFile(filePath: string): Promise<Keypair> {
-  const keypairString = await fs.readFile(filePath, {encoding: 'utf8'});
-  const keypairBuffer = Uint8Array.from(JSON.parse(keypairString));
-  return Keypair.fromSecretKey(keypairBuffer);
+export async function createKeypairFromFile(filePath: string): Promise<Keypair> {
+  const secretKeyString = await fs.readFile(filePath, {encoding: 'utf8'});
+  const secretKey = Uint8Array.from(JSON.parse(secretKeyString));
+  return Keypair.fromSecretKey(secretKey);
 }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -8,11 +8,6 @@ import path from 'path';
 import yaml from 'yaml';
 import {Keypair, Connection} from '@solana/web3.js';
 
-// zzz
-export function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 export async function newAccountWithLamports(
   connection: Connection,
   lamports = 1000000,

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -72,7 +72,9 @@ export async function getPayer(): Promise<Keypair> {
 /**
  * Create a Keypair from a secret key stored in file as bytes' array
  */
-export async function createKeypairFromFile(filePath: string): Promise<Keypair> {
+export async function createKeypairFromFile(
+  filePath: string,
+): Promise<Keypair> {
   const secretKeyString = await fs.readFile(filePath, {encoding: 'utf8'});
   const secretKey = Uint8Array.from(JSON.parse(secretKeyString));
   return Keypair.fromSecretKey(secretKey);


### PR DESCRIPTION
From the [doc](https://solana-labs.github.io/solana-web3.js/classes/account.html)

> deprecated
> 
>     since v1.10.0, please use Keypair instead.