### PR TITLE
Simplify keypair retrieval + airdrop

### DIFF
--- a/src/client/hello_world.ts
+++ b/src/client/hello_world.ts
@@ -15,11 +15,7 @@ import fs from 'mz/fs';
 import path from 'path';
 import * as borsh from 'borsh';
 
-import {
-  getPayer,
-  getRpcUrl,
-  createKeypairFromFile,
-} from './utils';
+import {getPayer, getRpcUrl, createKeypairFromFile} from './utils';
 
 /**
  * Connection to the network

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -6,7 +6,7 @@ import os from 'os';
 import fs from 'mz/fs';
 import path from 'path';
 import yaml from 'yaml';
-import {Keypair, Connection} from '@solana/web3.js';
+import {Keypair} from '@solana/web3.js';
 
 /**
  * @private

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -8,19 +8,6 @@ import path from 'path';
 import yaml from 'yaml';
 import {Keypair, Connection} from '@solana/web3.js';
 
-export async function newAccountWithLamports(
-  connection: Connection,
-  lamports = 1000000,
-): Promise<Keypair> {
-  const keypair = Keypair.generate();
-  const signature = await connection.requestAirdrop(
-    keypair.publicKey,
-    lamports,
-  );
-  await connection.confirmTransaction(signature);
-  return keypair;
-}
-
 /**
  * @private
  */
@@ -60,7 +47,7 @@ export async function getPayer(): Promise<Keypair> {
   try {
     const config = await getConfig();
     if (!config.keypair_path) throw new Error('Missing keypair path');
-    return createKeypairFromFile(config.keypair_path);
+    return await createKeypairFromFile(config.keypair_path);
   } catch (err) {
     console.warn(
       'Failed to create keypair from CLI config file, falling back to new random keypair',


### PR DESCRIPTION
- Add `return await` in `getPayer` to be able to catch `fs.readFile` errors in
case the keypair file is missing.

  This is an allowed case for the [no-return-await eslint rule](
https://github.com/eslint/eslint/blob/master/docs/rules/no-return-await.md#rule-details
)

- Thus, remove redundant function `newAccountWithLamports` and consolidate
airdrop in a single place to be used by loaded or generated keypairs.

- Add a call to `getBalance` after confirming the airdrop to show the proper
balance in logs.