### PR TITLE
update nodejs, solana cli version; .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .env
 src/client/util/store
 test-ledger/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ on your OS, they may already be installed:
 - Install node (v14 recommended)
 - Install npm
 - Install the latest Rust stable from https://rustup.rs/
-- Install Solana v1.7.8 or later from
+- Install Solana v1.7.11 or later from
   https://docs.solana.com/cli/install-solana-cli-tools
 
 If this is your first time using Rust, these [Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "typescript": "^4.0.5"
       },
       "engines": {
-        "node": "12.x"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "typescript": "^4.0.5"
   },
   "engines": {
-    "node": "12.x"
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
- Update `engines` `node` to >= `14.0.0` fit with README.md (https://github.com/solana-labs/example-helloworld#quick-start): `Install node (v14 recommended)`.
- Update requires min version of Solana CLI >= `1.7.11`, close https://github.com/solana-labs/example-helloworld/issues/290
- Add `.DS_Store` to `.gitignore` (macOS).