### PR TITLE
fix: start on gitpod failed

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,0 @@
-FROM gitpod/workspace-full
-
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.7.8/install)"
-RUN export PATH=~/.local/share/solana/install/active_release/bin:$PATH

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,7 @@
-image:
-  file: .gitpod.Dockerfile
 tasks:
   - init: |
       sh -c "$(curl -sSfL https://release.solana.com/v1.8.2/install)"
-      export PATH=~/.local/share/solana/install/active_release/bin:$PATH
-      gp env PATH=~/.local/share/solana/install/active_release/bin:$PATH
+      eval $(gp env -e PATH=$HOME/.local/share/solana/install/active_release/bin:$PATH)
       npm install
       npm run build:program-rust
     command: |

--- a/README-gitpod.md
+++ b/README-gitpod.md
@@ -36,9 +36,19 @@ The project comprises of:
 Using this example in Gitpod connects to the public Solana `devnet` cluster. Use
 the environment variable `CLUSTER` to choose a different Solana cluster.
 
+Start a local Solana cluster:
+```bash
+solana-test-validator
+```
+
+Deploy the on-chain program:
+```bash
+solana program deploy ./dist/program/helloworld.so
+```
+
 Run the client to load and interact with the on-chain program:
 ```bash
-$ npm run start
+npm run start
 ```
 
 The remaining sections of this document point back to the non-Gitpod version of


### PR DESCRIPTION
The environment of the Solana executable has not been set up correctly. See <https://www.gitpod.io/docs/environment-variables#using-the-command-line-gp-env>.

PTAL @jstarry 