### PR TITLE
must run solana-test-validator in home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This example connects to a local Solana cluster by default.
 
 Start a local Solana cluster:
 ```bash
+cd ~
 solana-test-validator
 ```
 > **Note**: You may need to do some [system tuning](https://docs.solana.com/running-validator/validator-start#system-tuning) (and restart your computer) to get the validator to run


### PR DESCRIPTION
```

example-helloworld on  update_solana_test_validator_instructions is 📦 v0.0.1 via ⬢ v17.7.1 on ☁️ geoff.langenderfer@gmail.com(us-central1)
❯ solana-test-validator
zsh: abort (core dumped)  solana-test-validator

example-helloworld on  update_solana_test_validator_instructions is 📦 v0.0.1 via ⬢ v17.7.1 on ☁️ geoff.langenderfer@gmail.com(us-central1)
❯ pwd
/home/g/work/example-helloworld

example-helloworld on  update_solana_test_validator_instructions is 📦 v0.0.1 via ⬢ v17.7.1 on ☁️ geoff.langenderfer@gmail.com(us-central1)
❯

```